### PR TITLE
protect vpc

### DIFF
--- a/dcf/main.tf
+++ b/dcf/main.tf
@@ -1,5 +1,9 @@
 locals {
-  allowed_https_domains = []
+  allowed_https_domains = [    
+    "aviatrix.com",
+    "*.amazonaws.com",
+    "cloud.google.com",
+    "*.microsoft.com"]
 }
 
 resource "aviatrix_web_group" "allow_internet_https" {


### PR DESCRIPTION
applications can only access the following domains:

    "aviatrix.com",
    "*.amazonaws.com",
    "cloud.google.com",
    "*.microsoft.com"
